### PR TITLE
Fix `ERR_UNSUPPORTED_DIR_IMPORT` error

### DIFF
--- a/templates/index.ts
+++ b/templates/index.ts
@@ -1,4 +1,4 @@
-export * from "@pgsql/types";
+export * from "@pgsql/types/index.js";
 
 // @ts-ignore
 import PgQueryModule from './libpg-query.js';

--- a/versions/13/src/index.ts
+++ b/versions/13/src/index.ts
@@ -5,7 +5,7 @@
  * npm run copy:templates
  */
 
-export * from "@pgsql/types";
+export * from "@pgsql/types/index.js";
 
 // @ts-ignore
 import PgQueryModule from './libpg-query.js';

--- a/versions/14/src/index.ts
+++ b/versions/14/src/index.ts
@@ -5,7 +5,7 @@
  * npm run copy:templates
  */
 
-export * from "@pgsql/types";
+export * from "@pgsql/types/index.js";
 
 // @ts-ignore
 import PgQueryModule from './libpg-query.js';

--- a/versions/15/src/index.ts
+++ b/versions/15/src/index.ts
@@ -5,7 +5,7 @@
  * npm run copy:templates
  */
 
-export * from "@pgsql/types";
+export * from "@pgsql/types/index.js";
 
 // @ts-ignore
 import PgQueryModule from './libpg-query.js';

--- a/versions/16/src/index.ts
+++ b/versions/16/src/index.ts
@@ -5,7 +5,7 @@
  * npm run copy:templates
  */
 
-export * from "@pgsql/types";
+export * from "@pgsql/types/index.js";
 
 // @ts-ignore
 import PgQueryModule from './libpg-query.js';

--- a/versions/17/src/index.ts
+++ b/versions/17/src/index.ts
@@ -5,7 +5,7 @@
  * npm run copy:templates
  */
 
-export * from "@pgsql/types";
+export * from "@pgsql/types/index.js";
 
 // @ts-ignore
 import PgQueryModule from './libpg-query.js';


### PR DESCRIPTION
Hey,

We are getting `ERR_UNSUPPORTED_DIR_IMPORT` and this fixes it.  Looks like the generated code is invalid when node is in esm mode.

```
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '<snip>/node_modules/.pnpm/@pgsql+parser@1.2.0/node_modules/@pgsql/parser/wasm/v17/types' is not supported resolving ES modules imported from <snip>/node_modules/.pnpm/@pgsql+parser@1.2.0/node_modules/@pgsql/parser/wasm/v17/index.js
```