### PR TITLE
fix: escape control characters in build_scan_json() for multi-line tokens

### DIFF
--- a/full/src/wasm_wrapper.c
+++ b/full/src/wasm_wrapper.c
@@ -379,8 +379,19 @@ static char* build_scan_json(PgQuery__ScanResult *scan_result, const char* origi
             char c = token_text[j];
             if (c == '"' || c == '\\') {
                 escaped_text[escaped_pos++] = '\\';
+                escaped_text[escaped_pos++] = c;
+            } else if (c == '\n') {
+                escaped_text[escaped_pos++] = '\\';
+                escaped_text[escaped_pos++] = 'n';
+            } else if (c == '\r') {
+                escaped_text[escaped_pos++] = '\\';
+                escaped_text[escaped_pos++] = 'r';
+            } else if (c == '\t') {
+                escaped_text[escaped_pos++] = '\\';
+                escaped_text[escaped_pos++] = 't';
+            } else {
+                escaped_text[escaped_pos++] = c;
             }
-            escaped_text[escaped_pos++] = c;
         }
         escaped_text[escaped_pos] = '\0';
         

--- a/full/test/scan.test.js
+++ b/full/test/scan.test.js
@@ -227,46 +227,53 @@ describe("Query Scanning", () => {
     });
 
     it("should handle multi-line dollar-quoted strings without JSON errors", () => {
-      // This tests that the JSON serialization properly escapes control
-      // characters (newlines, tabs) inside token text fields.
+      // Without the fix, scanSync throws:
+      //   "Bad control character in string literal"
+      // because build_scan_json() doesn't escape \n in the token text.
       const sql = `CREATE FUNCTION test() RETURNS void AS $$
 BEGIN
   RAISE NOTICE 'hello';
 END;
 $$ LANGUAGE plpgsql`;
-      
+
       const result = query.scanSync(sql);
       assert.equal(typeof result, "object");
       assert.ok(Array.isArray(result.tokens));
       assert.ok(result.tokens.length > 0);
-      
-      // Find the dollar-quoted string token
+
+      // The dollar-quoted body spans multiple lines
       const dollarToken = result.tokens.find(t => t.text.includes('BEGIN'));
       assert.ok(dollarToken, "should have a token containing the function body");
-      assert.ok(dollarToken.text.includes('\n'), "token text should contain newlines");
+      assert.ok(dollarToken.text.includes('\n'), "token text should preserve newlines");
     });
 
-    it("should handle multi-line tokens with tabs", () => {
-      const sql = "SELECT $$line1\n\tindented\nline3$$";
-      
+    it("should handle dollar-quoted tokens with tabs", () => {
+      // Tab characters also break JSON.parse when unescaped.
+      const sql = `SELECT $$line1
+	indented
+line3$$`;
+
       const result = query.scanSync(sql);
       assert.equal(typeof result, "object");
       assert.ok(Array.isArray(result.tokens));
-      
+
       const dollarToken = result.tokens.find(t => t.text.includes('indented'));
       assert.ok(dollarToken, "should have a token containing the tabbed content");
     });
 
-    it("should handle multi-line SQL comments", () => {
-      const sql = "SELECT 1; /* multi\nline\ncomment */ SELECT 2";
-      
+    it("should handle multi-line block comments", () => {
+      // C-style block comments spanning multiple lines hit the same bug.
+      const sql = `SELECT 1; /* multi
+line
+comment */ SELECT 2`;
+
       const result = query.scanSync(sql);
       assert.equal(typeof result, "object");
       assert.ok(Array.isArray(result.tokens));
-      
+
       const commentToken = result.tokens.find(t => t.tokenName === "C_COMMENT");
       assert.ok(commentToken, "should have a C_COMMENT token");
-      assert.ok(commentToken.text.includes('\n'), "comment text should contain newlines");
+      assert.ok(commentToken.text.includes('\n'), "comment text should preserve newlines");
     });
   });
 });

--- a/full/test/scan.test.js
+++ b/full/test/scan.test.js
@@ -225,5 +225,48 @@ describe("Query Scanning", () => {
       assert.equal(typeof result1.version, "number");
       assert.ok(result1.version > 0);
     });
+
+    it("should handle multi-line dollar-quoted strings without JSON errors", () => {
+      // This tests that the JSON serialization properly escapes control
+      // characters (newlines, tabs) inside token text fields.
+      const sql = `CREATE FUNCTION test() RETURNS void AS $$
+BEGIN
+  RAISE NOTICE 'hello';
+END;
+$$ LANGUAGE plpgsql`;
+      
+      const result = query.scanSync(sql);
+      assert.equal(typeof result, "object");
+      assert.ok(Array.isArray(result.tokens));
+      assert.ok(result.tokens.length > 0);
+      
+      // Find the dollar-quoted string token
+      const dollarToken = result.tokens.find(t => t.text.includes('BEGIN'));
+      assert.ok(dollarToken, "should have a token containing the function body");
+      assert.ok(dollarToken.text.includes('\n'), "token text should contain newlines");
+    });
+
+    it("should handle multi-line tokens with tabs", () => {
+      const sql = "SELECT $$line1\n\tindented\nline3$$";
+      
+      const result = query.scanSync(sql);
+      assert.equal(typeof result, "object");
+      assert.ok(Array.isArray(result.tokens));
+      
+      const dollarToken = result.tokens.find(t => t.text.includes('indented'));
+      assert.ok(dollarToken, "should have a token containing the tabbed content");
+    });
+
+    it("should handle multi-line SQL comments", () => {
+      const sql = "SELECT 1; /* multi\nline\ncomment */ SELECT 2";
+      
+      const result = query.scanSync(sql);
+      assert.equal(typeof result, "object");
+      assert.ok(Array.isArray(result.tokens));
+      
+      const commentToken = result.tokens.find(t => t.tokenName === "C_COMMENT");
+      assert.ok(commentToken, "should have a C_COMMENT token");
+      assert.ok(commentToken.text.includes('\n'), "comment text should contain newlines");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Fixes a bug in `build_scan_json()` where literal control characters (`\n`, `\r`, `\t`) in token text were written directly into the JSON string without escaping. This caused `JSON.parse` to throw "Bad control character in string literal" when scanning SQL containing multi-line tokens (e.g., dollar-quoted function bodies like `$$\nBEGIN\n...$$` or multi-line `/* */` comments).

The existing escape loop only handled `"` and `\`. This adds the three missing control character cases to produce valid JSON escape sequences (`\n` → `\\n`, etc.).

Three new tests added covering dollar-quoted strings with newlines, dollar-quoted tokens with tabs, and multi-line block comments. Tests use template literals with actual newlines/tabs so the multi-line SQL is visually obvious in the source code.

## Review & Testing Checklist for Human

- [ ] **Verify the if/else restructuring is correct** (`wasm_wrapper.c:379-396`): The original code used a flat `if` + unconditional `escaped_text[escaped_pos++] = c` which worked for `"` and `\` but silently passed through control chars. The new code uses an `if/else if/else` chain where each branch writes exactly the right pair of characters. Confirm no character is double-written or skipped.
- [ ] **Buffer size adequacy**: `escaped_text` is allocated as `token_length * 2 + 1`. Worst case is every char needing a 2-byte escape, so this is sufficient. But worth a glance.
- [ ] **Other control characters (0x00-0x1F)**: Only `\n`, `\r`, `\t` are handled. Other control chars are technically invalid in JSON strings but extremely unlikely in PostgreSQL token text. Decide if a general `c < 0x20` guard is worth adding.

**Test plan**: The new tests will only pass after a WASM rebuild (they exercise the C code path). CI should rebuild and run them. To verify manually: rebuild WASM with `pnpm wasm:build` in `/full`, then run `node --test test/scan.test.js` and confirm all tests pass, especially the three new multi-line token tests.

See also PR #148 which contains **only** these same tests without the C fix — CI fails there with the exact `"Bad control character in string literal"` errors, proving the fix is necessary.

### Notes
- The `scan` and `scanSync` functions in `index.cjs` call `JSON.parse` on the raw string returned by `_wasm_scan`. This fix ensures that string is always valid JSON.
- Downstream consumer `pgsql-parse` (PR #290 in pgsql-parser) has a `safeScanSync()` workaround that monkey-patches `JSON.parse` to fix this at the JS level. Once this fix is published, that workaround can be removed.

Link to Devin session: https://app.devin.ai/sessions/67facbcfe0ae424bad3eafb4e6ca9059
Requested by: @pyramation