### PR TITLE
test: prove scanSync JSON bug with multi-line tokens (expected to FAIL)

### DIFF
--- a/full/test/scan.test.js
+++ b/full/test/scan.test.js
@@ -227,47 +227,53 @@ describe("Query Scanning", () => {
     });
 
     it("should handle multi-line dollar-quoted strings without JSON errors", () => {
-      // This tests that the JSON serialization properly escapes control
-      // characters (newlines, tabs) inside token text fields.
-      // Without a fix, scanSync throws: "Bad control character in string literal"
+      // Without the fix, scanSync throws:
+      //   "Bad control character in string literal"
+      // because build_scan_json() doesn't escape \n in the token text.
       const sql = `CREATE FUNCTION test() RETURNS void AS $$
 BEGIN
   RAISE NOTICE 'hello';
 END;
 $$ LANGUAGE plpgsql`;
-      
+
       const result = query.scanSync(sql);
       assert.equal(typeof result, "object");
       assert.ok(Array.isArray(result.tokens));
       assert.ok(result.tokens.length > 0);
-      
-      // Find the dollar-quoted string token
+
+      // The dollar-quoted body spans multiple lines
       const dollarToken = result.tokens.find(t => t.text.includes('BEGIN'));
       assert.ok(dollarToken, "should have a token containing the function body");
-      assert.ok(dollarToken.text.includes('\n'), "token text should contain newlines");
+      assert.ok(dollarToken.text.includes('\n'), "token text should preserve newlines");
     });
 
-    it("should handle multi-line tokens with tabs", () => {
-      const sql = "SELECT $$line1\n\tindented\nline3$$";
-      
+    it("should handle dollar-quoted tokens with tabs", () => {
+      // Tab characters also break JSON.parse when unescaped.
+      const sql = `SELECT $$line1
+	indented
+line3$$`;
+
       const result = query.scanSync(sql);
       assert.equal(typeof result, "object");
       assert.ok(Array.isArray(result.tokens));
-      
+
       const dollarToken = result.tokens.find(t => t.text.includes('indented'));
       assert.ok(dollarToken, "should have a token containing the tabbed content");
     });
 
-    it("should handle multi-line SQL comments", () => {
-      const sql = "SELECT 1; /* multi\nline\ncomment */ SELECT 2";
-      
+    it("should handle multi-line block comments", () => {
+      // C-style block comments spanning multiple lines hit the same bug.
+      const sql = `SELECT 1; /* multi
+line
+comment */ SELECT 2`;
+
       const result = query.scanSync(sql);
       assert.equal(typeof result, "object");
       assert.ok(Array.isArray(result.tokens));
-      
+
       const commentToken = result.tokens.find(t => t.tokenName === "C_COMMENT");
       assert.ok(commentToken, "should have a C_COMMENT token");
-      assert.ok(commentToken.text.includes('\n'), "comment text should contain newlines");
+      assert.ok(commentToken.text.includes('\n'), "comment text should preserve newlines");
     });
   });
 });

--- a/full/test/scan.test.js
+++ b/full/test/scan.test.js
@@ -225,5 +225,49 @@ describe("Query Scanning", () => {
       assert.equal(typeof result1.version, "number");
       assert.ok(result1.version > 0);
     });
+
+    it("should handle multi-line dollar-quoted strings without JSON errors", () => {
+      // This tests that the JSON serialization properly escapes control
+      // characters (newlines, tabs) inside token text fields.
+      // Without a fix, scanSync throws: "Bad control character in string literal"
+      const sql = `CREATE FUNCTION test() RETURNS void AS $$
+BEGIN
+  RAISE NOTICE 'hello';
+END;
+$$ LANGUAGE plpgsql`;
+      
+      const result = query.scanSync(sql);
+      assert.equal(typeof result, "object");
+      assert.ok(Array.isArray(result.tokens));
+      assert.ok(result.tokens.length > 0);
+      
+      // Find the dollar-quoted string token
+      const dollarToken = result.tokens.find(t => t.text.includes('BEGIN'));
+      assert.ok(dollarToken, "should have a token containing the function body");
+      assert.ok(dollarToken.text.includes('\n'), "token text should contain newlines");
+    });
+
+    it("should handle multi-line tokens with tabs", () => {
+      const sql = "SELECT $$line1\n\tindented\nline3$$";
+      
+      const result = query.scanSync(sql);
+      assert.equal(typeof result, "object");
+      assert.ok(Array.isArray(result.tokens));
+      
+      const dollarToken = result.tokens.find(t => t.text.includes('indented'));
+      assert.ok(dollarToken, "should have a token containing the tabbed content");
+    });
+
+    it("should handle multi-line SQL comments", () => {
+      const sql = "SELECT 1; /* multi\nline\ncomment */ SELECT 2";
+      
+      const result = query.scanSync(sql);
+      assert.equal(typeof result, "object");
+      assert.ok(Array.isArray(result.tokens));
+      
+      const commentToken = result.tokens.find(t => t.tokenName === "C_COMMENT");
+      assert.ok(commentToken, "should have a C_COMMENT token");
+      assert.ok(commentToken.text.includes('\n'), "comment text should contain newlines");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds three test cases that **are expected to fail** on the current `main` branch, proving that `scanSync` / `scan` cannot handle SQL containing multi-line tokens.

The root cause: `build_scan_json()` in `full/src/wasm_wrapper.c` escapes `"` and `\` in token text but not `\n`, `\r`, or `\t`. When a token spans multiple lines (dollar-quoted function bodies, multi-line `/* */` comments), the raw JSON contains literal control characters, and `JSON.parse` throws `"Bad control character in string literal"`.

The three failing tests cover:
1. **Dollar-quoted function body** — a `CREATE FUNCTION` with a multi-line PL/pgSQL body
2. **Dollar-quoted string with tabs** — a `$$...$$` literal containing actual tab characters
3. **Multi-line block comment** — a `/* ... */` comment spanning multiple lines

All test SQL uses **template literals with actual newlines and tabs** so the failing input is visually obvious in the source code (no escape sequences).

**Do not merge this PR.** It exists to demonstrate the bug. See PR #147 for the fix that makes these tests pass.

## Review & Testing Checklist for Human

- [ ] **Verify CI failures are the expected ones**: The `Test full on *` jobs should fail with `SyntaxError: Bad control character in string literal in JSON` on the three new tests. If they fail for a different reason, something else is wrong.
- [ ] **Cross-reference with PR #147**: Confirm the fix PR's CI passes these same three tests (it does — 48/48 green).
- [ ] **Inspect the tab character in the "dollar-quoted tokens with tabs" test**: The template literal on line ~252 contains a real `\t` — verify it renders as a tab in the diff view, not a run of spaces.

### Notes
- No production code is changed — this is test-only.
- The diff also fixes a missing trailing newline at end of file.

Link to Devin session: https://app.devin.ai/sessions/67facbcfe0ae424bad3eafb4e6ca9059
Requested by: @pyramation