### PR TITLE
fix: update @pgsql/types dep to ^18.0.0 in versions/18

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
   versions/18:
     dependencies:
       '@pgsql/types':
-        specifier: ^17.6.2
-        version: 17.6.2
+        specifier: ^18.0.0
+        version: 18.0.0
 
 packages:
 

--- a/versions/18/package.json
+++ b/versions/18/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {},
   "dependencies": {
-    "@pgsql/types": "^17.6.2"
+    "@pgsql/types": "^18.0.0"
   },
   "keywords": [
     "sql",


### PR DESCRIPTION
## Summary

The `versions/18/package.json` was published as `libpg-query@18.0.0` with `@pgsql/types: "^17.6.2"` as its dependency. This causes downstream consumers (e.g. `pgsql-parser`) to resolve two copies of `@pgsql/types` (17.x and 18.x), leading to TypeScript type conflicts where `ParseResult` from libpg-query doesn't match `ParseResult` from the consumer's `@pgsql/types@18.0.0`.

**Change:** `@pgsql/types: "^17.6.2"` → `@pgsql/types: "^18.0.0"` in `versions/18/package.json`.

All other v18 packages (`types/18`, `enums/18`, `full/`, `parser/`) were checked — they either have no `@pgsql/types` dependency or already reference `^18.0.0`.

After merging, `libpg-query` should be republished (e.g. as `18.0.1`) with the `pg18` dist-tag so the fix propagates to consumers.

## Review & Testing Checklist for Human

- [ ] After merging, republish `libpg-query@pg18` with the corrected dependency
- [ ] Verify pgsql-parser can remove its pnpm override for `@pgsql/types` after the republish

### Notes

- This is a one-line dependency fix. No code changes.
- Related: constructive-io/pgsql-parser#297 (PG 18 upgrade, currently uses a pnpm override to work around this issue)

Link to Devin session: https://app.devin.ai/sessions/5d3588c124524869b388ced885962d70
Requested by: @pyramation