### PR TITLE
fix: detect parsePlPgSQL errors by non-JSON result instead of message prefix

### DIFF
--- a/templates/full/index.ts
+++ b/templates/full/index.ts
@@ -247,7 +247,8 @@ export const parsePlPgSQL = awaitInit(async (query: string): Promise<ParseResult
     resultPtr = wasmModule._wasm_parse_plpgsql(queryPtr);
     const resultStr = ptrToString(resultPtr);
     
-    if (resultStr.startsWith('syntax error') || resultStr.startsWith('deparse error') || resultStr.startsWith('ERROR')) {
+    // Success is always a JSON object; anything else is an error message
+    if (!resultStr.startsWith('{')) {
       throw new Error(resultStr);
     }
     
@@ -377,7 +378,8 @@ export function parsePlPgSQLSync(query: string): ParseResult {
     resultPtr = wasmModule._wasm_parse_plpgsql(queryPtr);
     const resultStr = ptrToString(resultPtr);
     
-    if (resultStr.startsWith('syntax error') || resultStr.startsWith('deparse error') || resultStr.startsWith('ERROR')) {
+    // Success is always a JSON object; anything else is an error message
+    if (!resultStr.startsWith('{')) {
       throw new Error(resultStr);
     }
     

--- a/versions/18/src/index.ts
+++ b/versions/18/src/index.ts
@@ -254,7 +254,8 @@ export const parsePlPgSQL = awaitInit(async (query: string): Promise<ParseResult
     resultPtr = wasmModule._wasm_parse_plpgsql(queryPtr);
     const resultStr = ptrToString(resultPtr);
     
-    if (resultStr.startsWith('syntax error') || resultStr.startsWith('deparse error') || resultStr.startsWith('ERROR')) {
+    // Success is always a JSON object; anything else is an error message
+    if (!resultStr.startsWith('{')) {
       throw new Error(resultStr);
     }
     
@@ -384,7 +385,8 @@ export function parsePlPgSQLSync(query: string): ParseResult {
     resultPtr = wasmModule._wasm_parse_plpgsql(queryPtr);
     const resultStr = ptrToString(resultPtr);
     
-    if (resultStr.startsWith('syntax error') || resultStr.startsWith('deparse error') || resultStr.startsWith('ERROR')) {
+    // Success is always a JSON object; anything else is an error message
+    if (!resultStr.startsWith('{')) {
       throw new Error(resultStr);
     }
     


### PR DESCRIPTION
## Summary
`wasm_parse_plpgsql` returns error messages as plain strings, but the JS side only recognized errors prefixed with `syntax error`/`deparse error`/`ERROR`. Any other PostgreSQL error message (e.g. `RETURN cannot have a parameter in function with OUT parameters`, `"x" is not a known variable`) fell through to `JSON.parse` and surfaced as a confusing `Unexpected token 'R', "RETURN can"... is not valid JSON` SyntaxError, swallowing the real message.

Since a successful parse always returns a JSON object (`{"plpgsql_funcs":...}`), `parsePlPgSQL`/`parsePlPgSQLSync` now treat any result not starting with `{` as an error:

```diff
- if (resultStr.startsWith('syntax error') || resultStr.startsWith('deparse error') || resultStr.startsWith('ERROR')) {
+ // Success is always a JSON object; anything else is an error message
+ if (!resultStr.startsWith('{')) {
    throw new Error(resultStr);
  }
```

Changed in `templates/full/index.ts` (source of truth) and the generated `versions/18/src/index.ts`. This was issue #1 in the earlier libpg-query@18.1.0 PL/pgSQL bug report; `fingerprint`/`normalize` keep their prefix checks since their success values are plain strings.

Link to Devin session: https://app.devin.ai/sessions/064ad193e1c040af8c145d55e07af9b8
Requested by: @pyramation