### PR TITLE
Add pnpm supply-chain policy (recipe A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,9 @@ jobs:
       - name: Install Dependencies 🧶
         run: pnpm install
 
+      - name: Check supply-chain policy
+        run: pnpm run policy:check
+
       - name: Install Parser Dependencies 📦
         run: pnpm install
         working-directory: parser

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "PostgreSQL query parser monorepo",
   "packageManager": "pnpm@8.15.0",
   "scripts": {
+    "policy": "pnpm-policy generate --builds-key onlyBuiltDependencies",
+    "policy:check": "pnpm-policy check --builds-key onlyBuiltDependencies",
     "build": "pnpm --filter libpg-query build",
     "test": "pnpm --filter libpg-query test",
     "clean": "pnpm --filter libpg-query clean",
@@ -32,10 +34,12 @@
     "publish:parser": "pnpm --filter @pgsql/parser publish"
   },
   "devDependencies": {
+    "@constructive-io/pnpm-policy": "0.2.1",
     "@types/node": "^20.0.0",
     "copyfiles": "^2.4.1",
     "glob": "11.0.3",
     "pg-proto-parser": "^1.28.2",
+    "pnpm-policy": "0.2.2",
     "rimraf": "^5.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@constructive-io/pnpm-policy':
+        specifier: 0.2.1
+        version: 0.2.1
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.1
@@ -20,6 +23,9 @@ importers:
       pg-proto-parser:
         specifier: ^1.28.2
         version: 1.28.2
+      pnpm-policy:
+        specifier: 0.2.2
+        version: 0.2.2
       rimraf:
         specifier: ^5.0.0
         version: 5.0.10
@@ -270,6 +276,10 @@ packages:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+    dev: true
+
+  /@constructive-io/pnpm-policy@0.2.1:
+    resolution: {integrity: sha512-tAgH3Zgwn2shQXGlfl5zxmtY/tyZw9jYX7QAOFMp5ALKSrxO5xsxZQmckwMqOeHyyV/MZJWzIZ4t/QYznJeVmw==}
     dev: true
 
   /@cspotcode/source-map-support@0.8.1:
@@ -777,12 +787,22 @@ packages:
     hasBin: true
     dev: true
 
+  /mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
   /nested-obj@0.0.1:
     resolution: {integrity: sha512-kB1WKTng+IePQhZVs1UXtFaHBx4QEM5a0XKGAzYfCKvdx5DhNjCytNDWMUGpNNpHLotln+tiwcA52kWCIgGq1Q==}
+    dev: true
+
+  /nested-obj@0.2.3:
+    resolution: {integrity: sha512-Py9HdJ/qECkQHvryUaPcaIou6t+U/mkpT66jG8al7jh8Opt3wAuTSSXdPDyY8r1ljEH8a0EH6M4YR28b+RQ8zg==}
     dev: true
 
   /noms@0.0.0:
@@ -846,6 +866,14 @@ packages:
 
   /picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+    dev: true
+
+  /pnpm-policy@0.2.2:
+    resolution: {integrity: sha512-Fj5/ACIZG/AGynTvhT8/7fJTf8ya3jG/Mkq/OMNVZhfTTJ1oniRTsKBHlXGF4sSecvIFqkmeHpn8CsQFwGcENA==}
+    hasBin: true
+    dependencies:
+      yaml: 2.9.0
+      yamlize: 0.12.1
     dev: true
 
   /process-nextick-args@2.0.1:
@@ -1058,6 +1086,20 @@ packages:
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+    dev: true
+
+  /yamlize@0.12.1:
+    resolution: {integrity: sha512-rU2BN+gmyr0A4yK5i/Ps9JO1MjQGIGUelkaFglc9i4QqEDKU5HfDMdHhNhGMoeNeVw7nJqWpmDiFnxGb6FR5zA==}
+    dependencies:
+      mkdirp: 3.0.1
+      nested-obj: 0.2.3
+      yaml: 2.9.0
     dev: true
 
   /yargs-parser@20.2.9:

--- a/pnpm-policy.yaml
+++ b/pnpm-policy.yaml
@@ -1,0 +1,39 @@
+# Supply-chain policy for this workspace. The pnpm settings it produces live in
+# pnpm-workspace.yaml under the `Managed by pnpm-policy` marker — edit this file,
+# then run `pnpm run policy`. `pnpm run policy:check` fails CI when they drift.
+
+# Third-party releases wait two days. A compromised release is normally reported
+# and yanked within hours, so the short wait catches it without stalling upgrades.
+minimumReleaseAge: 2d
+
+# Transitive dependencies must resolve from the registry, not from git or a URL.
+blockExoticSubdeps: true
+
+# The npm accounts WE publish under. Everything they publish skips the wait, so
+# this lists accounts we control — nobody else's.
+maintainers:
+  - pyramation
+
+# Scopes we own outright, emitted as `@scope/*` globs so they also cover packages
+# published there tomorrow.
+scopes:
+  - "@constructive-io"
+  - "@constructive-db"
+  - "@launchql"
+  - "@pgpm"
+  - "@pgpmjs"
+  - "@pgsql"
+
+# Resolved from the pinned data package rather than regenerated per repo.
+inventory: "@constructive-io/pnpm-policy/inventory.json"
+
+# Only emit the first-party names this lockfile actually resolves, instead of all
+# ~1100 we publish.
+intersect: true
+
+# Dependencies allowed to run install scripts. The value is the reason.
+allowBuilds: {}
+
+# Third-party escape hatches. A reason is required; `until` expires the waiver so
+# `check` makes you re-justify it instead of letting it live forever.
+exceptions: []

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,10 +1,10 @@
 packages:
   - 'parser'
   - 'versions/18'
-  - 'versions/17' 
-  - 'versions/16' 
-  - 'versions/15' 
-  - 'versions/14' 
+  - 'versions/17'
+  - 'versions/16'
+  - 'versions/15'
+  - 'versions/14'
   - 'versions/13'
   - 'types/18'
   - 'types/17'
@@ -17,4 +17,28 @@ packages:
   - 'enums/16'
   - 'enums/15'
   - 'enums/14'
-  - 'enums/13' 
+  - 'enums/13'
+
+# Managed by pnpm-policy — run `pnpm-policy generate` after editing pnpm-policy.yaml.
+
+# A third-party release must be 2d old before it can be installed.
+# Most malicious releases are found and yanked well inside that window.
+minimumReleaseAge: 2880
+
+# Exempt from the wait: 6 scope glob(s), 5 first-party package(s).
+# First-party membership comes from what pyramation publishes on npm — waiting on your own release protects nothing.
+minimumReleaseAgeExclude:
+  - "@constructive-db/*"
+  - "@constructive-io/*"
+  - "@launchql/*"
+  - "@pgpm/*"
+  - "@pgpmjs/*"
+  - "@pgsql/*"
+  - nested-obj
+  - pg-proto-parser
+  - pnpm-policy
+  - strfy-js
+  - yamlize
+
+# Transitive dependencies must come from the registry, not from git or a URL.
+blockExoticSubdeps: true


### PR DESCRIPTION
## Summary

Rolls out the org-wide pnpm supply-chain policy to this repo, part of constructive-io/constructive-planning#1464.

- Adds `pnpm-policy.yaml` at the workspace root:
  - `minimumReleaseAge: 2d` — third-party releases wait two days before they can be installed. Most malicious releases are found and yanked well inside that window, so this catches supply-chain compromises without stalling normal upgrades.
  - `blockExoticSubdeps: true` (default kept) — no git/URL-sourced transitive dependencies were found in `pnpm-lock.yaml`, so nothing needed loosening here.
  - `maintainers: [pyramation]` and our owned `scopes` (`@constructive-io`, `@constructive-db`, `@launchql`, `@pgpm`, `@pgpmjs`, `@pgsql`) are exempt from the wait — we publish those ourselves, so waiting protects nothing.
  - `intersect: true` — the exemption list in `pnpm-workspace.yaml` only lists the first-party packages this lockfile actually resolves (6 scope globs + 5 named packages), not the full ~1100 we publish org-wide. Derived automatically, not hand-maintained.
  - `allowBuilds: {}` — no install-script approvals were needed (see deviation note below).
  - `exceptions: []` — none needed.
- Adds `pnpm-policy` and `@constructive-io/pnpm-policy` (pinned exact at `0.2.1`, per `save-exact=true` in `.npmrc`) as root devDependencies.
- Adds `policy` / `policy:check` scripts to the root `package.json`.
- `pnpm run policy` patches the managed block into `pnpm-workspace.yaml` (packages/comments untouched).
- Wires `pnpm run policy:check` into `.github/workflows/ci.yml`, in the `build-parser` job, immediately after the root `pnpm install` step.

## Deviations from the standard recipe

- **pnpm version**: this repo pins `packageManager: pnpm@8.15.0`, which predates the `allowBuilds` key (needs pnpm >= 10.16). Both `policy` and `policy:check` scripts pass `--builds-key onlyBuiltDependencies` so the tool emits/checks the older key name. `pnpm-workspace.yaml` had no prior `onlyBuiltDependencies` entry, so there was nothing to carry over/delete.
- **allowBuilds is empty**: on pnpm 8.15.0, `pnpm install` ran all install scripts (`@launchql/protobufjs` postinstall, `parser` prepare) without any `ERR_PNPM_IGNORED_BUILDS` gate — that enforcement is a pnpm 9/10+ feature. So no packages needed an explicit approval entry. This repo builds via WASM (see `LOADING_WASM.md`), not node-gyp/native compilation, so there's no native-binding install step to approve either.
- **CI hook location**: chose the `build-parser` job (not matrixed, runs once per trigger) over the matrixed `build-wasm`/`test` jobs, to avoid running the check redundantly 6x per workflow run.

## Verification

All three passed locally before opening this PR:
```
pnpm run policy:check          # "matches the policy"
pnpm install --frozen-lockfile # succeeded
pnpm run policy                # "Unchanged" — shasum of pnpm-workspace.yaml identical before/after
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEswUi4ANuB58rva48aHge